### PR TITLE
#168803433 - A users will be able to delete their article posts - API Endpoint

### DIFF
--- a/server/controllers/articles.js
+++ b/server/controllers/articles.js
@@ -67,6 +67,27 @@ class allAboutArticle {
     });
 }
 
+static deleteArticle(req, res) {
+    const articleid = parseInt(req.params.id, 10);
+    let message = '';
+    articles.map((article, index) => {  
+        if (article.id === articleid) {
+            articles.splice(index, 1);
+            message = 'Article deleted successfuly'
+        }
+    });
+    if (message) {
+        return res.status(200).json({
+            status: '200',
+            message
+        });
+    }
+    return res.status(404).json({
+        status: '404',
+        message: 'Article not found'
+    });
+}
+
 static getAllarticle(req,res){
     const data = articles.sort(function(a, b){
         const dateA = new Date(a.createdOn), dateB = new Date(b.createdOn);

--- a/server/routes/articles.js
+++ b/server/routes/articles.js
@@ -12,5 +12,6 @@ router.get('/articles',tokenVerification, articles.getAllarticle);
 router.get('/articles/:id',tokenVerification,paramCheck.parameterCheck, articles.getSpecificArticle);
 router.patch('/articles/:id/:flag', tokenVerification, paramCheck.parameterCheckFlag, articles.editArticle);
 router.patch('/articles/:id', tokenVerification, loggedInUser.isAllowedToEdit, paramCheck.parameterCheck, articles.editArticle);
+router.delete('/articles/:id',tokenVerification,loggedInUser.isAllowed, paramCheck.parameterCheck, articles.deleteArticle);
 
 export default router;

--- a/server/test/articles.js
+++ b/server/test/articles.js
@@ -142,6 +142,44 @@ describe('post </api/v1/articles>  create article api', () => {
     });
   });
 
+  describe('patch </api/v1/articles>  delete Article api', () => {
+    it('article should be deleted', (done) => {
+      chai
+        .request(app)
+        .delete('/api/v1/articles/2')
+        .set('Authorization', `Bearer ${staffToken}`)
+        .end((err, res) => {
+          res.should.have.status(200);
+          res.body.should.have.be.a('object');
+          done();
+        });
+    });
+
+    it('should check if article exist', (done) => {
+      chai
+        .request(app)
+        .delete('/api/v1/articles/0')
+        .set('Authorization', `Bearer ${staffToken}`)
+        .end((err, res) => {
+          res.should.have.status(403);
+          res.body.should.have.be.a('object');
+          done();
+        });
+    });
+    it('should check if any user is allowed to delete others article', (done) => {
+      chai
+        .request(app)
+        .delete('/api/v1/articles/1')
+        .set('Authorization', `Bearer ${staffToken}`)
+        .end((err, res) => {
+          res.should.have.status(403);
+          res.body.should.have.be.a('object');
+          done();
+        });
+    });
+  });
+  
+
   describe('Get </api/v1/articles> Get a specific Article api', () => {
     it('Get a specific article', (done) => {
       chai


### PR DESCRIPTION
#### What does this PR do?
This PR adds an API endpoint feature which will enable the user to delete one/more of his articles. 

#### Description of Task to be completed?
A signed-in user will be able to delete his/her own article post. 

**A user**
**Will be able to delete one of my articles**
**So that it should be removed from article posts**

### Acceptance Criteria

``` 
Given a user
When type in this URL '/api/v1/articles/:id' using DELETE method.
Then the article will be deleted
```

#### How should this be manually tested?
```After cloning the repository 
go to the root of the project and open path into command 
then run the npm run dev:
Use Postman to test all endpoints;
Key: Content-Type value: application/JSON
Test endpoints
DELETE request
type in a URL  /api/v1/articles/:id
Set Authorization header
and once setup is done click npm test.
```

#### What are the relevant pivotal tracker stories?
[#168803433](https://www.pivotaltracker.com/story/show/168803433)

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/52475100/65840290-85cbf500-e317-11e9-9764-641dbf414dd6.png)