### PR TITLE
#168804540 - A user will be able to flag a comment API endpoint

### DIFF
--- a/server/controllers/comments.js
+++ b/server/controllers/comments.js
@@ -59,6 +59,29 @@ class comment {
       message: 'Article not found',
     });
   }
+
+  static flagComment(req, res) {
+    const id = parseInt(req.params.id, 10);
+    let message = '';
+    commentes.map((comment) => {
+      if (comment.id === id) {
+        comment.flag += 1;
+        message = comment;
+      }
+    });
+    if (message) {
+      return res.status(200).json({
+        status: '200',
+        message,
+      });
+    }
+    return res.status(404).json({
+      status: '404',
+      message: 'comment not found',
+    });
+  }
+
+
 }
 
 export default comment;

--- a/server/routes/comments.js
+++ b/server/routes/comments.js
@@ -6,5 +6,6 @@ import paramCheck from '../middleware/parameterCheck';
 const router = express.Router();
  
 router.post('/commentes/:id',tokenVerification, paramCheck.parameterCheck, comment.createComment); 
+router.patch('/commentes/:id',tokenVerification, paramCheck.parameterCheck, comment.flagComment);
 
 export default router;

--- a/server/test/comments.js
+++ b/server/test/comments.js
@@ -50,4 +50,30 @@ describe('post </api/v1/commentes>  create comment api', () => {
     });
   });
   
+  describe('patch </api/v1/commentes>  flag comment api', () => {
+    it('acomment should be flagged', (done) => {
+      chai
+        .request(app)
+        .patch('/api/v1/commentes/1')
+        .set('Authorization', `Bearer ${staffToken}`)
+        .end((err, res) => {
+          res.should.have.status(200);
+          res.body.should.have.be.a('object');
+          done();
+        });
+    });
+  
+    it('should check if comment exist', (done) => {
+      chai
+        .request(app)
+        .patch('/api/v1/commentes/0')
+        .set('Authorization', `Bearer ${staffToken}`)
+        .end((err, res) => {
+          res.should.have.status(404);
+          res.body.should.have.be.a('object');
+          done();
+        });
+    });
+  });
+  
   


### PR DESCRIPTION
#### What does this PR do?
This pull request adds a feature that will enable a user to flag a comment as inappropriate. 

#### Description of Task to be completed?
A user will be able to flag a comment as inappropriate. 

**A user**
**will be able to flag a comment**
**So that it can be marked as inappropriate for deletion**

### Acceptance Criteria
```
Given a user
When type in this URL 'api/v1/commentes/:id' using PATCH method 
In case he submits
Then the comment will be flagged
```
#### How should this be manually tested?
```
After cloning the repository 
go to the root of the project and open path into command 
then run the npm run dev:
Use Postman to test all endpoints;
Key: Content-Type value: application/JSON
Test endpoints
PATCH request
type in a URL  /api/v1/commentes/:id
Set Authorization header
and once setup is done click npm test.
```
#### What are the relevant pivotal tracker stories?
[#168804540](https://www.pivotaltracker.com/story/show/168804540)

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/52475100/65840520-8914b000-e31a-11e9-857d-2ac6add79e5d.png)
