### PR TITLE
#168804915 - Admin will be to delete a flagged comment - API Endpoint

### DIFF
--- a/server/controllers/comments.js
+++ b/server/controllers/comments.js
@@ -81,7 +81,26 @@ class comment {
     });
   }
 
-
+  static deleteComment(req, res) {
+    const commentid = parseInt(req.params.id, 10);
+    let message = '';
+    commentes.map((comment, index) => {
+      if (comment.id === commentid && comment.flag > 0) {
+        commentes.splice(index, 1);
+        message = 'comment deleted successfuly';
+      }
+    });
+    if (message) {
+      return res.status(200).json({
+        status: '200',
+        message,
+      });
+    }
+    return res.status(404).json({
+      status: '404',
+      message: 'Imposible to delete unflagging or unexistence comment',
+    });
+  }
 }
 
 export default comment;

--- a/server/middleware/loggedInUser.js
+++ b/server/middleware/loggedInUser.js
@@ -1,67 +1,67 @@
 import artcles from '../models/articles';
-
+import commentes from '../models/comments';
 class loggedinUser {
-    static isAllowedToDcmt(req, res, next) {
+    static isAllowedToDcmt(req,res,next){
         let message = '';
         const id = parseInt(req.params.id, 10);
-        commentes.map((comment) => {
-            if (req.user.type === 'admin' && comment.flag > 0 && comment.id === id) {
-                message = 'ok';
+        commentes.map((comment)=>{
+            if(req.user.type === 'admin' && comment.flag > 0 && comment.id === id){
+            message = 'ok';
             }
         });
 
-        if (message !== 'ok') {
+        if(message !== 'ok'){
             return res.status(403).json({
                 status: '403',
                 message: 'you are not allowed this kind of request only admin'
             });
         }
-        return next();
+    return next();
     }
-    static isAllowed(req, res, next) {
+    static isAllowed(req,res,next){
         let message = '';
         const id = parseInt(req.params.id, 10);
-        artcles.map((article) => {
-            if (req.user.type === 'admin' && article.flag > 0 && article.id === id) {
+        artcles.map((article)=>{
+            if(req.user.type === 'admin' && article.flag > 0 && article.id === id){
+            message = 'ok';
+            }else  if(article.creatorid === req.user.id && article.id === id){
                 message = 'ok';
-            } else if (article.creatorid === req.user.id && article.id === id) {
-                message = 'ok';
-            }
+           }
         });
-        if (message !== 'ok') {
+        if(message !== 'ok'){
             return res.status(403).json({
                 status: '403',
                 message: 'you are not allowed to edit others article'
             });
         }
-        return next();
+       return next();
     }
-    static isAllowedToEdit(req, res, next) {
+    static isAllowedToEdit(req,res,next){
         let message = '';
         const id = parseInt(req.params.id, 10);
-        artcles.map((article) => {
-            if (article.creatorid === req.user.id && article.id === id) {
-                message = 'ok';
-            }
+        artcles.map((article)=>{
+            if(article.creatorid === req.user.id && article.id === id){
+             message = 'ok';
+        }
         });
-        if (message !== 'ok') {
+        if(message !== 'ok'){
             return res.status(403).json({
                 status: '403',
                 message: 'you are not allowed to edit others article'
             });
         }
-        return next();
+       return next();
     }
 
-    static isAdmin(req, res, next) {
+    static isAdmin(req,res,next){
 
-        if (req.user.type !== 'admin') {
+        if(req.user.type !== 'admin' ){
             return res.status(401).json({
                 status: '401',
                 message: 'You are not allowed this kind of request, Only Admin'
             });
         }
-        return next();
+    return next();
     }
 
 }

--- a/server/routes/comments.js
+++ b/server/routes/comments.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import comment from '../controllers/comments';
+import loggedInUser from '../middleware/loggedInUser';
 import tokenVerification from '../middleware/tokenVerification';
 import paramCheck from '../middleware/parameterCheck';
 
@@ -7,5 +8,6 @@ const router = express.Router();
  
 router.post('/commentes/:id',tokenVerification, paramCheck.parameterCheck, comment.createComment); 
 router.patch('/commentes/:id',tokenVerification, paramCheck.parameterCheck, comment.flagComment);
+router.delete('/commentes/:id',tokenVerification,loggedInUser.isAllowedToDcmt, paramCheck.parameterCheck, comment.deleteComment);
 
 export default router;

--- a/server/test/comments.js
+++ b/server/test/comments.js
@@ -76,4 +76,41 @@ describe('post </api/v1/commentes>  create comment api', () => {
     });
   });
   
+  describe('delete </api/v1/commentes>  delete comment api', () => {
+    it('flagged acomment should be deleted', (done) => {
+      chai
+        .request(app)
+        .delete('/api/v1/commentes/3')
+        .set('Authorization', `Bearer ${admintoken}`)
+        .end((err, res) => {
+          res.should.have.status(200);
+          res.body.should.have.be.a('object');
+          done();
+        });
+    });
+  
+    it('should check if comment exist', (done) => {
+      chai
+        .request(app)
+        .delete('/api/v1/commentes/0')
+        .set('Authorization', `Bearer ${admintoken}`)
+        .end((err, res) => {
+          res.should.have.status(403);
+          res.body.should.have.be.a('object');
+          done();
+        });
+    });
+
+    it('should check if a staff is allowed to delete', (done) => {
+      chai
+        .request(app)
+        .delete('/api/v1/commentes/3')
+        .set('Authorization', `Bearer ${staffToken}`)
+        .end((err, res) => {
+          res.should.have.status(403);
+          res.body.should.have.be.a('object');
+          done();
+        });
+    });
+  });
   


### PR DESCRIPTION
#### What does this PR do?
This pull request adds an API endpoint feature that enables an admin to delete flagged comments.

#### Description of Task to be completed?
An admin will be able to delete a flagged comment.
**An admin**
**Will be able to delete a flagged comment**
**So that it can be removed from comments list**

### Acceptance Criteria
```
Given an admin
When submit this URL '/api/v1/commentes/:id' with DELETE method 
Then the flagged comment will be deleted
```
#### How should this be manually tested?
```
After cloning the repository 
go to the root of the project and open path into command 
then run the npm run dev:

Use Postman to test all endpoints;
Key: Content-Type value: application/JSON
Test endpoints
DELETE request
type in a URL  /api/v1/commentes/:id
Set Authorization header
and once setup is done click npm test.
```
#### What are the relevant pivotal tracker stories?
[#168804915](https://www.pivotaltracker.com/story/show/168804915)

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/52475100/65840770-2244c600-e31d-11e9-9175-b3ee93c92d6c.png)